### PR TITLE
Added a method to initialize a FlagSet

### DIFF
--- a/pkg/legacyflag/flag.go
+++ b/pkg/legacyflag/flag.go
@@ -32,6 +32,11 @@ func NewFlagSet(name string) *FlagSet {
 	}
 }
 
+// NewFromPFlagSet creates a new FlagSet given a PFlagSet.
+func NewFromPFlagSet(fs *pflag.FlagSet) *FlagSet {
+	return &FlagSet{fs: fs}
+}
+
 // PflagFlagSet returns the underlying pflag.FlagSet.
 func (fs *FlagSet) PflagFlagSet() *pflag.FlagSet {
 	return fs.fs


### PR DESCRIPTION
This can be used to initialize a FlagSet given a pflag.FlagSet.
Useful for converting pflg.FlagSets to FlagSets.

Signed-off-by: alejandrox1 <alarcj137@gmail.com>

